### PR TITLE
Add corsMiddleware for all routes

### DIFF
--- a/server/src/lib/server.ts
+++ b/server/src/lib/server.ts
@@ -41,7 +41,7 @@ const corsMiddleware = cors({
   }
 });
 
-app.options('*', corsMiddleware)
+app.options('/api/*', corsMiddleware)
 
 app.post('/api/validate.json', corsMiddleware, (req, res) => {
   const url = req.body.url;

--- a/server/src/lib/server.ts
+++ b/server/src/lib/server.ts
@@ -41,7 +41,8 @@ const corsMiddleware = cors({
   }
 });
 
-app.options('/api/validate.json', corsMiddleware);
+app.options('*', corsMiddleware)
+
 app.post('/api/validate.json', corsMiddleware, (req, res) => {
   const url = req.body.url;
 
@@ -56,7 +57,6 @@ app.post('/api/validate.json', corsMiddleware, (req, res) => {
   return res.status(400).json({ error: { message: 'Missing url' } });
 });
 
-app.options('/api/seo-scores', corsMiddleware);
 app.post('/api/seo-scores', corsMiddleware, seoScoreHandler);
 
 app.get('/validate-robots', validateRobotsHandler);


### PR DESCRIPTION
- We noticed that an OPTIONS request gets made for every request and we did not have any handler for it for "/api/validate". 

- Added a common cors handler for all OPTIONS requests

Please refer below link for more information.
https://medium.com/@dvelasquez/handle-an-options-request-with-cors-in-node-js-f3f81c5a7494

> ..., all this happens because when you are using a cross origin request (CORS), the browser or application will send an OPTIONS petition first to make sure you have the privileges to excecute a petition like POST, GET, PUT, etc. Apparently, Postman will send the request you asked for only. In the other hand, browsers will send OPTIONS request first and then, the actual request. 