### PR TITLE
Duplicate slug

### DIFF
--- a/client/src/migrator/validator-utils.js
+++ b/client/src/migrator/validator-utils.js
@@ -53,7 +53,7 @@ function formErrorMetadata (dataType, affectedData, effect = 'Affected') {
 
 function parseResult (result) {
   let finalResult = {}
-  const { dataType, total, successful, additionalProperties, type, required, enum: wrongEnumValue, minLength, maxLength, error, errorKeys } = result
+  const { dataType, total, successful, additionalProperties, type, required, enum: wrongEnumValue, minLength, maxLength, error, errorKeys, minItems } = result
 
   finalResult.errors = []
   finalResult.warnings = []
@@ -81,9 +81,17 @@ function parseResult (result) {
   })
 
   minLength && minLength.forEach(error => {
-    let [ key, subPath ] = error.key.split(':')
+    let [ key, limit ] = error.key.split(':')
     finalResult.errors.push({
-      message: `${dataType} should have minimum of ${subPath} characters for property '${key}'.`,
+      message: `${dataType} should have minimum of ${limit} character${limit > 1 ? 's' : ''} for property '${key}'.`,
+      metadata: formErrorMetadata(dataType, error.ids)
+    })
+  })
+
+  minItems && minItems.forEach(error => {
+    let [ key, limit ] = error.key.split(':')
+    finalResult.errors.push({
+      message: `${dataType} should have minimum of ${limit} ${limit > 1 ? key : key.slice(0, key.length-1 )}.`,
       metadata: formErrorMetadata(dataType, error.ids)
     })
   })
@@ -92,7 +100,7 @@ function parseResult (result) {
     let [ key, subPath ] = error.key.split(':')
     subPath = (subPath === dataType) ? '' : ` in '${subPath}'.`
     finalResult.errors.push({
-      message: `${dataType} should have required property '${key}' ${subPath}`,
+      message: `${dataType} should have required property '${key}' ${subPath}.`,
       metadata: formErrorMetadata(dataType, error.ids)
     })
   })
@@ -101,7 +109,7 @@ function parseResult (result) {
     let [ key, subPath ] = warning.key.split(':')
     subPath = (subPath === dataType) ? '' : ` in '${subPath}'.`
     finalResult.warnings.push({
-      message: `${dataType} has additional property '${key}' ${subPath}`,
+      message: `${dataType} has additional property '${key}' ${subPath}.`,
       metadata: formErrorMetadata(dataType, warning.ids)
     })
   })

--- a/client/src/migrator/validator-utils.js
+++ b/client/src/migrator/validator-utils.js
@@ -53,7 +53,7 @@ function formErrorMetadata (dataType, affectedData, effect = 'Affected') {
 
 function parseResult (result) {
   let finalResult = {}
-  const { dataType, total, successful, additionalProperties, type, required, enum: wrongEnumValue, error, errorKeys } = result
+  const { dataType, total, successful, additionalProperties, type, required, enum: wrongEnumValue, minLength, maxLength, error, errorKeys } = result
 
   finalResult.errors = []
   finalResult.warnings = []
@@ -71,6 +71,22 @@ function parseResult (result) {
     }
     finalResult.errors.push(errorObject)
   }
+
+  maxLength && maxLength.forEach(error => {
+    let [ key, subPath ] = error.key.split(':')
+    finalResult.errors.push({
+      message: `${dataType} should have maximum of ${subPath} characters for property '${key}'.`,
+      metadata: formErrorMetadata(dataType, error.ids)
+    })
+  })
+
+  minLength && minLength.forEach(error => {
+    let [ key, subPath ] = error.key.split(':')
+    finalResult.errors.push({
+      message: `${dataType} should have minimum of ${subPath} characters for property '${key}'.`,
+      metadata: formErrorMetadata(dataType, error.ids)
+    })
+  })
 
   required && required.forEach(error => {
     let [ key, subPath ] = error.key.split(':')

--- a/client/src/migrator/validator-utils.js
+++ b/client/src/migrator/validator-utils.js
@@ -53,7 +53,7 @@ function formErrorMetadata (dataType, affectedData, effect = 'Affected') {
 
 function parseResult (result) {
   let finalResult = {}
-  const { dataType, total, successful, additionalProperties, type, required, enum: wrongEnumValue, minLength, maxLength, error, errorKeys, minItems } = result
+  const { dataType, total, successful, additionalProperties, type, required, enum: wrongEnumValue, minLength, maxLength, error, errorKeys, minItems, uniqueKey } = result
 
   finalResult.errors = []
   finalResult.warnings = []
@@ -92,6 +92,14 @@ function parseResult (result) {
     let [ key, limit ] = error.key.split(':')
     finalResult.errors.push({
       message: `${dataType} should have minimum of ${limit} ${limit > 1 ? key : key.slice(0, key.length-1 )}.`,
+      metadata: formErrorMetadata(dataType, error.ids)
+    })
+  })
+
+  uniqueKey && uniqueKey.forEach(error => {
+    let [ key, value ] = error.key.split(':')
+    finalResult.errors.push({
+      message: `${key} '${value}' is not unique.`,
       metadata: formErrorMetadata(dataType, error.ids)
     })
   })

--- a/server/src/lib/handlers/validator.spec.ts
+++ b/server/src/lib/handlers/validator.spec.ts
@@ -9,11 +9,16 @@ export const typesPath = join(
 );
 
 const testSchema = JSON.parse(readFileSync(path.resolve(__dirname,'..', '..', '..', 'test-data', 'test_schema.json'), 'utf8'));
+const storySchema = generateJsonSchema(path.resolve(__dirname, '..', '..', '..', 'test-data', 'editor-test.ts'), 'StoryTest');
 const authorSchema = generateJsonSchema(path.resolve(__dirname, '..', '..', '..', 'test-data', 'editor-test.ts'), 'AuthorTest');
 
 describe('generateJsonSchema', () => {
   it('just returns the schema of author test', () => {
     expect(authorSchema).toEqual(testSchema.definitions.AuthorTest);
+  });
+
+  it('just returns the schema of story test', () => {
+    expect(storySchema).toEqual(testSchema.definitions.StoryTest);
   });
 });
 
@@ -33,6 +38,29 @@ describe('validateJsonTest', () => {
     expect(validateJson(Author2, authorSchema)).toEqual(
       expect.arrayContaining([expect.objectContaining({"message": "should NOT be longer than 10 characters"})]));
     expect(validateJson(Author3, authorSchema)).toBeNull();
+  });
+
+  it('should validate json', () => {
+    const Story1 = {
+      name: 'story 1'
+    };
+    const Story2 = {
+      name: 'Story name',
+      sections: [],
+      authors: []
+    };
+    const Story3 = {
+      name: 'Foobar',
+      sections: [{ name: 'sec1'}],
+      authors: [{ name: 'foobar'}]
+    };
+    expect(validateJson(Story1, storySchema)).toEqual(
+      expect.arrayContaining(
+        [expect.objectContaining({"message": "should have required property 'sections'"}),
+         expect.objectContaining({"message": "should have required property 'authors'"})]));
+    expect(validateJson(Story2, storySchema)).toEqual(
+      expect.arrayContaining([expect.objectContaining({"message": "should NOT have fewer than 1 items"})]));
+    expect(validateJson(Story3, storySchema)).toBeNull();
   });
 });
 
@@ -347,6 +375,30 @@ describe('storyValidationTest', () => {
     expect(output).toEqual(
       expect.objectContaining(
         {additionalProperties: [{ key: 'foo:Story', ids: ['story-001'] }] })
+    );
+  });
+
+  it('should throw "minItems" error if authors or sections are empty arrays', () => {
+    const Story = {
+      'external-id': 'story-001',
+      headline: 'A story headline',
+      slug: 'story-slug',
+      'summary': 'Story Summary.',
+      'body': '<p>Some Body</p>',
+      'story-template': 'text',
+      status: 'published',
+      'first-published-at': 1020,
+      'last-published-at': 1020,
+      'published-at': 1020,
+      authors: [],
+      sections: [],
+      tags: [{ name: 'tag' }]
+    };
+    const output = validator('Story', Story, {});
+    expect(output).toEqual(
+      expect.objectContaining(
+        {minItems: [{ key: 'sections:1', ids: ['story-001'] },
+                    { key: 'authors:1', ids: ['story-001']}]})
     );
   });
 

--- a/server/src/lib/utils/error-parser.ts
+++ b/server/src/lib/utils/error-parser.ts
@@ -85,6 +85,8 @@ function getErrorParam(error: Obj, schema: string): string | boolean {
       return (keyPath + ':' + error.params.limit)
     case 'minLength':
       return (keyPath + ':' + error.params.limit)
+    case 'minItems':
+      return (keyPath + ':' + error.params.limit)
 // handle other keyword errors if required
   }
   return false

--- a/server/src/lib/utils/error-parser.ts
+++ b/server/src/lib/utils/error-parser.ts
@@ -81,6 +81,10 @@ function getErrorParam(error: Obj, schema: string): string | boolean {
       return (keyPath + ':' + error.params.type)
     case 'enum':
       return (keyPath + ':' + error.params.allowedValues)
+    case 'maxLength':
+      return (keyPath + ':' + error.params.limit)
+    case 'minLength':
+      return (keyPath + ':' + error.params.limit)
 // handle other keyword errors if required
   }
   return false

--- a/server/src/lib/utils/error-parser.ts
+++ b/server/src/lib/utils/error-parser.ts
@@ -87,6 +87,8 @@ function getErrorParam(error: Obj, schema: string): string | boolean {
       return (keyPath + ':' + error.params.limit)
     case 'minItems':
       return (keyPath + ':' + error.params.limit)
+    case 'uniqueKey':
+      return (keyPath + ':' + error.params.value)
 // handle other keyword errors if required
   }
   return false

--- a/server/test-data/editor-test.ts
+++ b/server/test-data/editor-test.ts
@@ -21,6 +21,9 @@ export interface StoryTest {
   */
   readonly sections: ReadonlyArray<SectionTest>;
 
+  /** Slug of story */
+  readonly slug?: string;
+
   /** List of story authors */
   readonly authors: ReadonlyArray<AuthorTest>;
 }

--- a/server/test-data/editor-test.ts
+++ b/server/test-data/editor-test.ts
@@ -16,7 +16,9 @@ export interface AuthorTest {
 export interface StoryTest {
   /** Name of story */
   readonly name: string;
-  /** List of sections story belongs to */
+  /** List of sections story belongs to 
+   * @minItems 1
+  */
   readonly sections: ReadonlyArray<SectionTest>;
 
   /** List of story authors */

--- a/server/test-data/editor-test.ts
+++ b/server/test-data/editor-test.ts
@@ -6,7 +6,10 @@ export interface SectionTest {
 
 /** Author Definition */
 export interface AuthorTest {
-  /** Name of Author */
+  /** Name of Author 
+   * @minLength 1
+   * @maxLength 10
+  */
   readonly name: string;
 }
 

--- a/server/test-data/test_schema.json
+++ b/server/test-data/test_schema.json
@@ -10,7 +10,9 @@
           "properties": {
             "name": {
               "description": "Name of Author",
-              "type": "string"
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 10
             }
           },
           "required": ["name"],

--- a/server/test-data/test_schema.json
+++ b/server/test-data/test_schema.json
@@ -52,6 +52,10 @@
               "type": "string",
               "description": "Name of story"
             },
+            "slug": {
+              "type": "string",
+              "description": "Slug of story"
+            },
             "sections": {
               "type": "array",
               "minItems": 1,

--- a/server/test-data/test_schema.json
+++ b/server/test-data/test_schema.json
@@ -54,6 +54,7 @@
             },
             "sections": {
               "type": "array",
+              "minItems": 1,
               "items": {
                 "$ref": "#/definitions/SectionTest"
               },
@@ -93,6 +94,8 @@
           "properties": {
             "name": {
               "description": "Name of Author",
+              "minLength": 1,
+              "maxLength": 10,
               "type": "string"
             }
           },


### PR DESCRIPTION
Added feature of checking presence of duplicate slugs. Works for an datatype( Story, Tag, Section) having property `slug`.
https://github.com/quintype/quintype-validator/issues/42